### PR TITLE
add home page page and route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import "./assets/styles/user-all.scss"
 
 import ScrollToTop from './components/ScrollToTop/ScrollToTop';
+import HomePage from './pages/HomePage/HomePage';
 import Login from './pages/Login/Login';
 import Signup from './pages/Signup/Signup'
 import EditProfile from './pages/EditProfile/EditProfile';
@@ -16,6 +17,7 @@ function App() {
     <>
       <ScrollToTop />
       <Routes>
+      <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/member/profile" element={<EditProfile />}></Route>

--- a/src/components/MemberSidebar/MemberSidebar.jsx
+++ b/src/components/MemberSidebar/MemberSidebar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Link } from "react-router-dom";
 
 function MemberSidebar({ children }){
     const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -46,8 +46,10 @@ function MemberSidebar({ children }){
             <div className="px-2">
               <strong>
                 <div className="d-flex flex-column d-md-block align-bottom align-items-center pb-2">
+                <Link to="/" className="navbar-brand d-flex align-items-center">
                   <i className="bi bi-cup-hot-fill fs-4 pe-md-2"></i>
                   <span className="fs-md-5">築豆咖啡</span>
+                </Link>
                 </div>
               </strong>
               <div className="d-flex flex-column flex-md-row align-items-center py-3">

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,11 +1,13 @@
+import { Link } from "react-router-dom";
+
 function Navbar(){
   return(
     <nav className="navbar navbar-expand-lg navbar-dark bg-coffee px-lg-5 sticky-top shadow ">
-      <div className="container-fluid " style={{ maxWidth: '1000px' }}>
-        <a className="navbar-brand" href="#">
-          <i className="bi bi-cup-hot-fill pe-3 fs-5"></i>
-          <span className="text-sm align-middle">築豆咖啡</span>
-        </a>
+      <div className="container-fluid" style={{ maxWidth: '1000px' }}>
+      <Link to="/" className="navbar-brand">
+        <i className="bi bi-cup-hot-fill pe-3 fs-5"></i>
+        <span className="text-sm align-middle">築豆咖啡</span>
+      </Link>
 
         {/* 漢堡選單按鈕 */}
         <button

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,0 +1,8 @@
+function HomePage() {
+    return(<>
+    <p className='d-flex justify-content-center align-items-center vh-100'>這是首頁</p>
+    </>
+    )
+}
+
+export default HomePage;


### PR DESCRIPTION
This PR adds a basic homepage route and page component for demonstration purposes. No UI layout or styling has been implemented yet.

Changes include:
- Added React Router route for "/"
- Added HomePage component
- Verified basic navigation works without frontend styling