### PR TITLE
add admin page and route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Login from './pages/Login/Login';
 import Signup from './pages/Signup/Signup'
 import EditProfile from './pages/EditProfile/EditProfile';
 import Contact from './pages/Contact/Contact';
+import Admin from './pages/Admin/Admin';
 
 import "./assets/styles/user-datepicker.scss"
 
@@ -23,6 +24,7 @@ function App() {
         <Route path="/signup" element={<Signup />} />
         <Route path="/member/profile" element={<EditProfile />}></Route>
         <Route path="/contact" element={<Contact />}></Route>
+        <Route path="/admin" element={<Admin />}></Route>
       </Routes>
     </>
   );

--- a/src/pages/Admin/Admin.jsx
+++ b/src/pages/Admin/Admin.jsx
@@ -1,0 +1,8 @@
+function Admin() {
+    return(<>
+    <p className='d-flex justify-content-center align-items-center vh-100'>這是後台管理員</p>
+    </>
+    )
+}
+
+export default Admin;


### PR DESCRIPTION
This PR adds a basic homepage route and page component for demonstration purposes. No UI layout or styling has been implemented yet.

Changes include:

- Added React Router route for "/admin"
- Added Admin component
- Verified basic navigation works without frontend styling