### PR TITLE
feat(cart): implement carousel for recommended products with pagination and navigation

### DIFF
--- a/src/assets/styles/cart-style.scss
+++ b/src/assets/styles/cart-style.scss
@@ -614,7 +614,6 @@
       color: $coffee-primary-800;
       font-weight: 900;
     }
-
     // 箭頭
     &-btn {
       font-size: 1.8rem;

--- a/src/assets/styles/cart-style.scss
+++ b/src/assets/styles/cart-style.scss
@@ -614,6 +614,24 @@
       color: $coffee-primary-800;
       font-weight: 900;
     }
+    // 點點：輪播頁碼
+    .recommend-dots {
+      display: flex;
+      justify-content: center;
+      gap: 24px;
+    
+      .dot {
+        width: 12px;
+        height: 12px;
+        background-color: $coffee-grey-200;
+        border-radius: 50%;
+        cursor: pointer;
+    
+        &.active {
+          background-color: $coffee-secondary-500;
+        }
+      }
+    }
     // 箭頭
     &-btn {
       font-size: 1.8rem;

--- a/src/pages/CartList/CartList.jsx
+++ b/src/pages/CartList/CartList.jsx
@@ -440,6 +440,23 @@ const CartList = () => {
   const perRecommendPage = 4;
   const totalRecommendPages = Math.ceil(recommendList.length / perRecommendPage);
 
+  const handleRecommendPrev = () => {
+    setRecommendPage((prev) =>
+      prev === 0 ? totalRecommendPages - 1 : prev - 1,
+    );
+  };
+
+  const handleRecommendNext = () => {
+    setRecommendPage((prev) =>
+      prev === totalRecommendPages - 1 ? 0 : prev + 1,
+    );
+  };
+
+  const currentRecommendList = recommendList.slice(
+    recommendPage * perRecommendPage,
+    recommendPage * perRecommendPage + perRecommendPage,
+  );
+
   return (
     <>
       <Header />

--- a/src/pages/CartList/CartList.jsx
+++ b/src/pages/CartList/CartList.jsx
@@ -424,7 +424,9 @@ const CartList = () => {
   // 取得推薦商品
   const getBestSeller = useCallback(async () => {
     try {
-      const res = await axios.get(`${apiUrl}/api/v1/products/bestSeller`);
+      const res = await axios.get(
+        `${apiUrl}/api/v1/products/bestSeller?limit=12`,
+      );
       setRecommendList(res.data?.data || []);
     } catch (error) {
       console.error('取得推薦商品失敗', error);

--- a/src/pages/CartList/CartList.jsx
+++ b/src/pages/CartList/CartList.jsx
@@ -931,6 +931,16 @@ const CartList = () => {
                 </div>
               </button>
             </div>
+            {/* 輪播「點點頁碼」指示器 */}
+            <div className="recommend-dots">
+              {Array.from({ length: totalRecommendPages }).map((_, i) => (
+                <span
+                  key={i}
+                  className={`dot ${i === recommendPage ? 'active' : ''}`}
+                  onClick={() => setRecommendPage(i)}
+                ></span>
+              ))}
+            </div>
           </div>
         </div>
         <div></div>

--- a/src/pages/CartList/CartList.jsx
+++ b/src/pages/CartList/CartList.jsx
@@ -18,6 +18,7 @@ const CartList = () => {
   const [couponError, setCouponError] = useState('');
   const [addingId, setAddingId] = useState(null);
   const [recommendList, setRecommendList] = useState([]);
+  const [recommendPage, setRecommendPage] = useState(0);
 
   const navigate = useNavigate();
   const apiUrl = import.meta.env.VITE_API_URL;
@@ -435,7 +436,9 @@ const CartList = () => {
     getBestSeller();
   }, [getCart, getBestSeller]);
 
-  
+  // 推薦商品用分頁輪播
+  const perRecommendPage = 4;
+  const totalRecommendPages = Math.ceil(recommendList.length / perRecommendPage);
 
   return (
     <>

--- a/src/pages/CartList/CartList.jsx
+++ b/src/pages/CartList/CartList.jsx
@@ -854,7 +854,11 @@ const CartList = () => {
           <div className="recommend-custom">
             <h5 className="recommend-title m-0">本期推薦</h5>
             <div className="recommend-card">
-              <button type="button" className="recommend-custom-btn border-0" on>
+              <button
+                type="button"
+                className="recommend-custom-btn border-0"
+                onClick={handleRecommendPrev}
+              >
                 <div className="arrow-icon">
                   <img
                     src={images.reviewArrowL}
@@ -865,7 +869,7 @@ const CartList = () => {
               </button>
 
               <div className="card-group">
-                {recommendList.map((item) => (
+                {currentRecommendList.map((item) => (
                   <div
                     className="card recommend-card-style m-0 rounded-0 border-0"
                     key={item.id}
@@ -911,7 +915,11 @@ const CartList = () => {
                 ))}
               </div>
 
-              <button type="button" className="recommend-custom-btn border-0">
+              <button
+                type="button"
+                className="recommend-custom-btn border-0"
+                onClick={handleRecommendNext}
+              >
                 <div className="arrow-icon">
                   <img
                     src={images.reviewArrowR}


### PR DESCRIPTION
This PR introduces a complete carousel functionality for the "Recommended Products" section on the CartList page, including the following changes:

1. Expanded the number of recommended items from 4 to 12.
2. Added pagination states and slicing logic for per-page rendering (4 items per page).
3. Implemented `handleRecommendPrev` and `handleRecommendNext` functions for page navigation.
4. Replaced static rendering with `currentRecommendList.map(...)` and bound onClick events to navigation buttons.
5. Added dot-based pagination indicator with clickable page switching.
6. Adjusted the API call in CartList to request 12 items using the `limit` query.
7. Styled the new pagination dots in `cart-style.scss`.

All changes are scoped to the CartList page. The Home page continues using the default 4-item behavior without modification.